### PR TITLE
Celery should be optional dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ import influxdb_metrics as app
 
 
 install_requires = [
-    'celery>=3.0.0',
     'django>=1.7',
     'influxdb>=2.9.1',
     'tld',


### PR DESCRIPTION
Since Celery is not really required, I prefer to avoid pulling it as a dependency whenever installing django-influxdb-metrics via pip