### PR TITLE
Fix exception

### DIFF
--- a/influxdb_metrics/utils.py
+++ b/influxdb_metrics/utils.py
@@ -61,6 +61,6 @@ def process_points(client, data):  # pragma: no cover
         client.write_points(data)
     except Exception as err:
         if getattr(settings, 'INFLUXDB_FAIL_SILENTLY', True):
-            logger.error(err)
+            logger.exception('Error while writing data points')
         else:
             raise

--- a/influxdb_metrics/utils.py
+++ b/influxdb_metrics/utils.py
@@ -63,4 +63,4 @@ def process_points(client, data):  # pragma: no cover
         if getattr(settings, 'INFLUXDB_FAIL_SILENTLY', True):
             logger.error(err)
         else:
-            raise err
+            raise


### PR DESCRIPTION
Hi!

Thanks for the nice and concise influx db logging package. While using it I got an error and I had a hard time figuring out what was wrong. All the log said was:

	Aug 30 17:45:54 0a6db8e6d57a localhost [2017-08-30 17:45:54] ERROR [influxdb_metrics.utils:64] main:

This pull request proposes two changes:

1. Use `logging.exception` instead of `logging.error`, the former includes information from the current exception including stack trace (though it will cause the log entry to be multi-line). This helped me solve my issue in seconds.
2. In the else block (when silent logging is turned off), re-raise the last exception instead of raising the last exception again. This will de-clutter the traceback by not including the 'raise err' line, which doesn't add anything useful.

Thanks!