### PR TITLE
Add compatibility with Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "2.7"
+  - "3.6"
 install: 
   - pip install -r test_requirements.txt --use-mirrors
   - pip install coveralls

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:3.6
 
 MAINTAINER Adrián Ribao adrian@adrima.es
 

--- a/README.rst
+++ b/README.rst
@@ -233,7 +233,7 @@ If you want to contribute to this project, please perform the following steps
 
     # Fork this repository
     # Clone your fork
-    mkvirtualenv -p python2.7 django-influxdb-metrics
+    mkvirtualenv -p python3.6 django-influxdb-metrics
     make develop
 
     git co -b feature_branch master

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ machine:
 dependencies:
   override:
     - pip install tox tox-pyenv
-    - pyenv local 2.7.12 3.5.2
+    - pyenv local 2.7.12 3.6.0
 
 test:
   override:

--- a/influxdb_metrics/middleware.py
+++ b/influxdb_metrics/middleware.py
@@ -1,4 +1,6 @@
 """Middlewares for the influxdb_metrics app."""
+
+from django import VERSION as DJANGO_VERSION
 import inspect
 import time
 try:
@@ -17,6 +19,13 @@ from tld import get_tld
 from tld.exceptions import TldBadUrl, TldDomainNotFound, TldIOError
 
 from .loader import write_points
+
+if DJANGO_VERSION < (1, 10):
+    def is_user_authenticated(user):
+        return user.is_authenticated()
+else:
+    def is_user_authenticated(user):
+        return user.is_authenticated
 
 
 class InfluxDBRequestMiddleware(MiddlewareMixin):
@@ -55,7 +64,7 @@ class InfluxDBRequestMiddleware(MiddlewareMixin):
             is_authenticated = False
             is_staff = False
             is_superuser = False
-            if request.user.is_authenticated():
+            if is_user_authenticated(request.user):
                 is_authenticated = True
                 if request.user.is_staff:
                     is_staff = True

--- a/influxdb_metrics/tests/urls.py
+++ b/influxdb_metrics/tests/urls.py
@@ -1,13 +1,23 @@
 """URLs to run the tests."""
-try:
-    from django.conf.urls import include, url
-except ImportError:  # Pre-Django 1.4 version
-    from django.conf.urls.defaults import include, url
 from django.contrib import admin
+
+from django import VERSION as DJANGO_VERSION
 
 
 admin.autodiscover()
 
-urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
-]
+if DJANGO_VERSION < (2, 0):
+    if DJANGO_VERSION < (1, 4):
+        from django.conf.urls.defaults import include, url
+    else:
+        from django.conf.urls import include, url
+    urlpatterns = [
+        url(r'^admin/', include(admin.site.urls)),
+    ]
+else:
+    from django.urls import path
+    urlpatterns = [
+        path('admin/', admin.site.urls),
+    ]
+
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-django{16,17,18,19},py35-django19
+envlist = py27-django{16,17,18,19},py36-django{19,110,111,200}
 
 [testenv]
 usedevelop = True
@@ -9,5 +9,8 @@ deps =
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2.0
+    django200: Django>=2.0,<2.1
     -rtest_requirements.txt
 commands = python runtests.py


### PR DESCRIPTION
- new URLconf style for test environment
- user.is_authenticated is now a bool, see #24
- Django 2.0 drops support for Python 2, so Python 3 is needed for development
- Added tox tests for Django 1.10, 1.11 and 2.0

Closes #24

Is circleci / travis still in use for this project? I updated the config files to use Python 3.6 instead of 3.5 to conform with the dev environment.