### PR TITLE
Catch possible connection issues with the MQ

### DIFF
--- a/influxdb_metrics/middleware.py
+++ b/influxdb_metrics/middleware.py
@@ -112,4 +112,8 @@ class InfluxDBRequestMiddleware(MiddlewareMixin):
                 },
                 'fields': {'value': ms, },
             }]
-            write_points(data)
+            try:
+                write_points(data)
+            except Exception as err:
+                pass  # sadly, when using celery, there can be issues with the connection to the MQ. Better to drop the data
+                # than fail the request.


### PR DESCRIPTION
In systems with limited resources, there is a well known problem that celery/rabbitmq cannot handle too many requests. Therefore it's possible that the connection to the MQ fails with errors such as ```ConnectionError: Error 104 while writing to socket. Connection reset by peer.```. In that case, the entire request fails, which is very sad. This commit protects the request by silently failing to register the data to upload.