### PR TITLE
Adding setting to override 'django_' measurement prefix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,11 @@ Optional with ssl::
 
     INFLUXDB_VERIFY_SSL = True # default is False
 
+Specify a prefix for metric measurement names (default is 'django_', E.g. 'django_request')
+
+    INFLUXDB_PREFIX = "my_app"     # measurement name == 'my_app_request'
+    INFLUXDB_PREFIX = ""           # measurement name == 'request'
+    INFLUXDB_PREFIX = None         # measurement name == 'request'
 
 Usage
 -----

--- a/influxdb_metrics/email.py
+++ b/influxdb_metrics/email.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 from django.core.mail.backends.smtp import EmailBackend
 from django.conf import settings
 
-from .loader import write_points
+from .loader import measurement_name_for, write_points
 
 
 class InfluxDbEmailBackend(EmailBackend):
@@ -17,7 +17,7 @@ class InfluxDbEmailBackend(EmailBackend):
             email_messages)
         if num_sent:
             data = [{
-                'measurement': 'django_email_sent',
+                'measurement': measurement_name_for('email_sent'),
                 'tags': {'host': settings.INFLUXDB_TAGS_HOST, },
                 'fields': {'value': num_sent, },
                 'time': timezone.now().isoformat(),

--- a/influxdb_metrics/loader.py
+++ b/influxdb_metrics/loader.py
@@ -1,4 +1,6 @@
 """Loads celery or non-celery version."""
+from functools import lru_cache
+
 from django.conf import settings
 
 try:
@@ -13,3 +15,18 @@ if getattr(settings, 'INFLUXDB_USE_CELERY', False):
     write_points = write_points_celery.delay
 else:
     write_points = write_points_normal
+
+
+@lru_cache(maxsize=32)
+def measurement_name_for(measurement: str) -> str:
+    """ Allow a configurable prefix for InfluxDB measurement names
+
+        Default (no INFLUXDB_PREFIX setting):              'django_request'
+        Custom Prefix (INFLUXDB_PREFIX="app"):                'app_request'
+        Empty Prefix (INFLUXDB_PREFIX="", INFLUXDB_PREFIX=None):  'request'
+
+    """
+    prefix = getattr(settings, 'INFLUXDB_PREFIX', 'django')
+    prefix = prefix if prefix else ""   # Replace None with ""
+    sep = "_" if prefix else ""
+    return '{}{}{}'.format(prefix, sep, measurement)

--- a/influxdb_metrics/middleware.py
+++ b/influxdb_metrics/middleware.py
@@ -18,7 +18,7 @@ except ImportError:
 from tld import get_tld
 from tld.exceptions import TldBadUrl, TldDomainNotFound, TldIOError
 
-from .loader import write_points
+from .loader import measurement_name_for, write_points
 
 if DJANGO_VERSION < (1, 10):
     def is_user_authenticated(user):
@@ -94,7 +94,7 @@ class InfluxDBRequestMiddleware(MiddlewareMixin):
                 campaign = url_query[campaign_keyword][0]
 
             data = [{
-                'measurement': 'django_request',
+                'measurement': measurement_name_for('request'),
                 'tags': {
                     'host': settings.INFLUXDB_TAGS_HOST,
                     'is_ajax': is_ajax,
@@ -114,6 +114,8 @@ class InfluxDBRequestMiddleware(MiddlewareMixin):
             }]
             try:
                 write_points(data)
-            except Exception as err:
-                pass  # sadly, when using celery, there can be issues with the connection to the MQ. Better to drop the data
+            except Exception:
+                # sadly, when using celery, there can be issues with
+                # the connection to the MQ. Better to drop the data
                 # than fail the request.
+                pass

--- a/influxdb_metrics/models.py
+++ b/influxdb_metrics/models.py
@@ -6,13 +6,13 @@ from django.contrib.auth.signals import user_logged_in
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 
-from .loader import write_points
+from .loader import measurement_name_for, write_points
 
 
 @receiver(user_logged_in)  # pragma: no cover
 def user_logged_in_handler(sender, **kwargs):
     data = [{
-        'measurement': 'django_auth_user_login',
+        'measurement': measurement_name_for('auth_user_login'),
         'tags': {'host': settings.INFLUXDB_TAGS_HOST, },
         'fields': {'value': 1, },
         'time': timezone.now().isoformat(),
@@ -24,7 +24,7 @@ def user_post_delete_handler(sender, **kwargs):
     """Sends a metric to InfluxDB when a User object is deleted."""
     total = get_user_model().objects.all().count()
     data = [{
-        'measurement': 'django_auth_user_delete',
+        'measurement': measurement_name_for('auth_user_delete'),
         'tags': {'host': settings.INFLUXDB_TAGS_HOST, },
         'fields': {'value': 1, },
         'time': timezone.now().isoformat(),
@@ -32,7 +32,7 @@ def user_post_delete_handler(sender, **kwargs):
     write_points(data)
 
     data = [{
-        'measurement': 'django_auth_user_count',
+        'measurement': measurement_name_for('auth_user_count'),
         'tags': {'host': settings.INFLUXDB_TAGS_HOST, },
         'fields': {'value': total, },
         'time': timezone.now().isoformat(),
@@ -48,7 +48,7 @@ def user_post_save_handler(**kwargs):
     if kwargs.get('created'):
         total = get_user_model().objects.all().count()
         data = [{
-            'measurement': 'django_auth_user_create',
+            'measurement': measurement_name_for('auth_user_create'),
             'tags': {'host': settings.INFLUXDB_TAGS_HOST, },
             'fields': {'value': 1, },
             'time': timezone.now().isoformat(),
@@ -56,7 +56,7 @@ def user_post_save_handler(**kwargs):
         write_points(data)
 
         data = [{
-            'measurement': 'django_auth_user_count',
+            'measurement': measurement_name_for('auth_user_count'),
             'tags': {'host': settings.INFLUXDB_TAGS_HOST, },
             'fields': {'value': total, },
             'time': timezone.now().isoformat(),

--- a/influxdb_metrics/tests/loader_tests.py
+++ b/influxdb_metrics/tests/loader_tests.py
@@ -1,0 +1,35 @@
+"""Tests for the loader module of the influxdb_metrics app."""
+from django.test import TestCase
+
+from .. import loader
+
+
+class LoaderMeasurementPrefixTestCase(TestCase):
+    """Tests for the ``INFLUXDB_PREFIX`` setting."""
+    longMessage = True
+
+    def test_default_prefix(self):
+        self.assertEqual(
+            loader.measurement_name_for('request'),
+            'django_request'
+        )
+
+    def test_custom_prefix(self):
+        with self.settings(INFLUXDB_PREFIX='test'):
+            self.assertEqual(
+                loader.measurement_name_for('metric'),
+                'test_metric'
+            )
+
+    def test_empty_prefix(self):
+        with self.settings(INFLUXDB_PREFIX=''):
+            self.assertEqual(
+                loader.measurement_name_for('thing1'),
+                'thing1'
+            )
+
+        with self.settings(INFLUXDB_PREFIX=None):
+            self.assertEqual(
+                loader.measurement_name_for('thing2'),
+                'thing2'
+            )

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,10 @@ def read(fname):
 setup(
     name="django-influxdb-metrics",
     version=app.__version__,
-    description="A reusable Django app that sends metrics about your project to InfluxDB",
+    description=(
+        "A reusable Django app that sends metrics "
+        "about your project to InfluxDB"
+    ),
     long_description=read('README.rst'),
     license='The MIT License',
     platforms=['OS Independent'],


### PR DESCRIPTION
A new setting, `INFLUXDB_PREFIX` allows for a custom prefix for influxdb metric measurement names:

```
Default (no INFLUXDB_PREFIX setting):              'django_request'
Custom Prefix (INFLUXDB_PREFIX="app"):                'app_request'
Empty Prefix (INFLUXDB_PREFIX="", INFLUXDB_PREFIX=None):  'request'
```

Use Case:
If I'm logging multiple django app metrics to the same InfluxDB instance, my only app separation is INFLUXDB_TAG usage. But this requires manual tag selection if I want to aggregate data across tiers. With this new setting, I can modify the metric measurement names to be app specific and use tags for tiers.