### PR TITLE
Add ignore_result=True

### DIFF
--- a/influxdb_metrics/tasks.py
+++ b/influxdb_metrics/tasks.py
@@ -12,7 +12,7 @@ except ImportError:
 from .utils import write_points as write_points_normal
 
 
-@shared_task
+@shared_task(ignore_result=True)
 def write_points(data, name='influxdb_metrics.tasks.write_points'):
     """
     Wrapper around `utils.write_points`.


### PR DESCRIPTION
There is a long standing issue with Celery and the redis result backend where results stored *must* be read to clear redis. Moreover, this task returns nothing, so we can safely mark the result to be ignored.