### PR TITLE
Converts local `shared_task` to a factory decorator to mimic `celery.shared_task` API

### DIFF
--- a/influxdb_metrics/tasks.py
+++ b/influxdb_metrics/tasks.py
@@ -4,10 +4,12 @@ from __future__ import absolute_import
 try:
     from celery import shared_task
 except ImportError:
-    def shared_task(func):
-        def wrapper(*args, **kwargs):
-            return func(*args, **kwargs)
-        return wrapper
+    def shared_task(*args, **kwargs):
+        def decorator(func):
+            def wrapper(*args, **kwargs):
+                return func(*args, **kwargs)
+            return wrapper
+        return decorator
 
 from .utils import write_points as write_points_normal
 


### PR DESCRIPTION
Resolves this issue: https://github.com/bitlabstudio/django-influxdb-metrics/issues/36